### PR TITLE
FIX - preventing negative array size

### DIFF
--- a/contrib/cover.js
+++ b/contrib/cover.js
@@ -432,7 +432,8 @@ function getSegments(code, lines, count, statementDetails) {
     // Will now be sorted in start order with end as the second sort criterium
     splintered = [];
     for ( i = 0; i < sd.length; i++) {
-        var us = new Array(sd[i].end - sd[i].start + 1);
+        var size = (sd[i].end - sd[i].start + 1 < 0) ? 0 : sd[i].end - sd[i].start + 1;
+        var us = new Array(size);
         for (k = sd[i].end - sd[i].start; k >= 0; k--) {
             us[k] = 1;                
         }


### PR DESCRIPTION
This pull request aim to prevent negative array size when calculating "segments".
A code snippet similar to this 

```
    myobj.myattr = myFunctionCall({ 
        onlyOneAttributeHere: 0
    });
```

was causing a crash in the gulp task
