### PR TITLE
Updated README, added gulp-coveralls example

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ To instrument and report on a file using Mocha as your test runner:
     cover = require('gulp-coverage');
 
     gulp.task('test', function () {
-        return gulp.src(['src.js', 'src2.js'], { read: false })
+        return gulp.src('tests/**/*.js', { read: false })
                 .pipe(cover.instrument({
-                    pattern: ['**/test*'],
+                    pattern: ['src/**/*.js'],
                     debugDirectory: 'debug'
                 }))
                 .pipe(mocha())
@@ -65,15 +65,34 @@ To instrument and report using Jasmine as your test system:
     cover = require('gulp-coverage');
 
     gulp.task('jasmine', function () {
-        return gulp.src('srcjasmine.js')
+        return gulp.src('tests/**/*.js')
                 .pipe(cover.instrument({
-                    pattern: ['**/test*'],
+                    pattern: ['src/**/*.js'],
                     debugDirectory: 'debug'
                 }))
                 .pipe(jasmine())
                 .pipe(cover.gather())
                 .pipe(cover.format())
                 .pipe(gulp.dest('reports'));
+    });
+```
+
+To report coverage with gulp-coveralls:
+
+```js
+    mocha = require('gulp-mocha');
+    cover = require('gulp-coverage');
+    coveralls = require('gulp-coveralls');
+
+    gulp.task('coveralls', function () {
+        return gulp.src('tests/**/*.js', { read: false })
+                .pipe(cover.instrument({
+                    pattern: ['src/**/*.js']
+                }))
+                .pipe(mocha()) // or .pipe(jasmine()) if using jasmine
+                .pipe(cover.gather())
+                .pipe(cover.format({ reporter: 'lcov' }))
+                .pipe(coveralls());
     });
 ```
 


### PR DESCRIPTION
Two small documentation changes:
* Changed the file paths in the examples to be less confusing - `gulp.src()` takes the test files, `cover.instrument()` takes the source files being covered. The paths used in the examples seem to imply the opposite. It's obvious enough when adding coverage to an existing test runner task, but #32 suggests I'm not the first to be momentarily confused..
* Added an example for usage with [gulp-coveralls](https://github.com/markdalgleish/gulp-coveralls). I've since seen there's a good example in the gulpfile.js, but the readme suggests it's not even possible (says json and html are the only supported formats). I only realised how simple it is after seeing #25 and since I'd guess it's a fairly common use case, maybe deserves its own example?